### PR TITLE
Add migration proofs for Olympus

### DIFF
--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -199,6 +199,7 @@ BITCOIN_CORE_H = \
   policy/fees.h \
   policy/policy.h \
   pow.h \
+  proof.h \
   protocol.h \
   random.h \
   reverse_iterator.h \
@@ -320,6 +321,7 @@ libpolis_server_a_SOURCES = \
   pow.cpp \
   privatesend.cpp \
   privatesend-server.cpp \
+  proof.cpp \
   rest.cpp \
   rpc/blockchain.cpp \
   rpc/masternode.cpp \

--- a/src/coins.cpp
+++ b/src/coins.cpp
@@ -65,6 +65,29 @@ bool CCoinsViewCache::GetCoin(const COutPoint &outpoint, Coin &coin) const {
     return false;
 }
 
+std::vector<std::pair<COutPoint, Coin>> CCoinsViewCache::GetAllCoins() const {
+    std::vector<std::pair<COutPoint, Coin>> coins;
+
+    for (CCoinsViewCursor *iter = base->Cursor(); iter->Valid(); iter->Next()) {
+        COutPoint key;
+        if (!iter->GetKey(key)) {
+            continue;
+        }
+        Coin val;
+        if (!iter->GetValue(val)) {
+            continue;
+        }
+
+        coins.push_back(std::make_pair(key, val));
+    }
+
+    std::sort(coins.begin(), coins.end(), [](const std::pair<COutPoint, Coin>& a, const std::pair<COutPoint, Coin>& b) -> bool {
+        return a.first.hash < b.first.hash || a.first.n < b.first.n;
+    });
+
+    return coins;
+}
+
 void CCoinsViewCache::AddCoin(const COutPoint &outpoint, Coin&& coin, bool possible_overwrite) {
     assert(!coin.IsSpent());
     if (coin.out.scriptPubKey.IsUnspendable()) return;

--- a/src/coins.cpp
+++ b/src/coins.cpp
@@ -78,11 +78,26 @@ std::vector<std::pair<COutPoint, Coin>> CCoinsViewCache::GetAllCoins() const {
             continue;
         }
 
-        coins.push_back(std::make_pair(key, val));
+        coins.emplace_back(key, val);
     }
 
     std::sort(coins.begin(), coins.end(), [](const std::pair<COutPoint, Coin>& a, const std::pair<COutPoint, Coin>& b) -> bool {
-        return a.first.hash < b.first.hash || a.first.n < b.first.n;
+        int cmpResult = a.first.hash.Compare(b.first.hash);
+        if (cmpResult < 0) {
+            return true;
+        }
+        if (cmpResult > 0) {
+            return false;
+        }
+
+        if (a.first.n < b.first.n) {
+            return true;
+        }
+        if (a.first.n > b.first.n) {
+            return false;
+        }
+
+        return false;
     });
 
     return coins;

--- a/src/coins.h
+++ b/src/coins.h
@@ -298,6 +298,8 @@ public:
     //! Check whether all prevouts of the transaction are present in the UTXO set represented by this view
     bool HaveInputs(const CTransaction& tx) const;
 
+    std::vector<std::pair<COutPoint, Coin>> GetAllCoins() const;
+
 private:
     CCoinsMap::iterator FetchCoin(const COutPoint &outpoint) const;
 
@@ -305,6 +307,7 @@ private:
      * By making the copy constructor private, we prevent accidentally using it when one intends to create a cache on top of a base cache.
      */
     CCoinsViewCache(const CCoinsViewCache &);
+
 };
 
 //! Utility function to add all of a transaction's outputs to a cache.

--- a/src/init.cpp
+++ b/src/init.cpp
@@ -90,12 +90,15 @@
 #include <boost/interprocess/sync/file_lock.hpp>
 #include <boost/thread.hpp>
 #include <openssl/crypto.h>
+#include <consensus/merkle.h>
 
 #if ENABLE_ZMQ
 #include "zmq/zmqnotificationinterface.h"
 #endif
 
 extern void ThreadSendAlert(CConnman& connman);
+
+uint256 CalcCoinMerkleRoot(CCoinsViewCache *pCache);
 
 bool fFeeEstimatesInitialized = false;
 static const bool DEFAULT_PROXYRANDOMIZE = true;
@@ -1891,6 +1894,10 @@ bool AppInitMain(boost::thread_group& threadGroup, CScheduler& scheduler)
         }
     }
 
+    auto *pcoinstip = new CCoinsViewCache(pcoinsdbview);
+    uint256 transactionMerkleRoot = CalcCoinMerkleRoot(pcoinstip);
+    LogPrintf("Coin merkle root: %s at %d\n", transactionMerkleRoot.ToString(), chainActive.Height());
+
     // As LoadBlockIndex can take several minutes, it's possible the user
     // requested to kill the GUI during the last operation. If so, exit.
     // As the program has not fully started yet, Shutdown() is possibly overkill.
@@ -2146,4 +2153,20 @@ bool AppInitMain(boost::thread_group& threadGroup, CScheduler& scheduler)
     threadGroup.create_thread(boost::bind(&ThreadSendAlert, boost::ref(connman)));
 
     return !fRequestShutdown;
+}
+
+uint256 CalcCoinMerkleRoot(CCoinsViewCache *pCache) {
+    auto coins = pCache->GetAllCoins();
+
+    std::vector<uint256> outpointHashes;
+    outpointHashes.resize(coins.size());
+
+    std::transform(coins.begin(), coins.end(), outpointHashes.begin(), [](const std::pair<COutPoint, Coin> in) -> uint256 {
+        CHashWriter ss(SER_GETHASH, 0);
+        ss << in.first;
+        ss << in.second;
+        return ss.GetHash();
+    });
+
+    return ComputeMerkleRoot(outpointHashes);
 }

--- a/src/proof.cpp
+++ b/src/proof.cpp
@@ -1,0 +1,24 @@
+// Copyright (c) 2020 Julian Meyer
+// Distributed under the MIT software license, see the accompanying
+// file COPYING or http://www.opensource.org/licenses/mit-license.php.
+
+#include <vector>
+#include "consensus/merkle.h"
+#include "proof.h"
+
+uint256 CalcCoinMerkleRoot(CCoinsViewCache *cc) {
+    auto coins = cc->GetAllCoins();
+
+    std::vector<uint256> outpointHashes;
+    outpointHashes.resize(coins.size());
+
+    std::transform(coins.begin(), coins.end(), outpointHashes.begin(), [](const std::pair<COutPoint, Coin> in) -> uint256 {
+        CHashWriter ss(SER_GETHASH, 0);
+        ss << in.first;
+        ss << in.second.out.nValue;
+        ss << in.second.out.scriptPubKey;
+        return ss.GetHash();
+    });
+
+    return ComputeMerkleRoot(outpointHashes);
+}

--- a/src/proof.h
+++ b/src/proof.h
@@ -1,0 +1,63 @@
+// Copyright (c) 2020 Julian Meyer
+// Distributed under the MIT software license, see the accompanying
+// file COPYING or http://www.opensource.org/licenses/mit-license.php.
+
+#ifndef BITCOIN_PROOF_H
+#define BITCOIN_PROOF_H
+
+#include "serialize.h"
+#include "uint256.h"
+#include "coins.h"
+
+class COutPoint;
+
+class CCoinsProof
+{
+public:
+    CCoinsProof(std::vector<uint256> merkleBranch, CTransaction tx, uint32_t index, CScript scriptPubKey):
+        merkleBranch(merkleBranch), tx(tx), merkleIndex(index), scriptPubKey(scriptPubKey) {};
+
+    ADD_SERIALIZE_METHODS;
+
+    template <typename Stream, typename Operation>
+    inline void SerializationOp(Stream& s, Operation ser_action)
+    {
+        READWRITE(merkleIndex);
+        READWRITE(merkleBranch);
+        READWRITE(tx);
+        READWRITE(scriptPubKey);
+    }
+
+private:
+
+    uint32_t merkleIndex;
+    std::vector<uint256> merkleBranch;
+    CTransaction tx;
+
+    CScript scriptPubKey;
+};
+
+uint256 CalcCoinMerkleRoot(CCoinsViewCache *pCache);
+
+/**
+Example of usage
+================
+
+auto *pcoinstip = new CCoinsViewCache(pcoinsdbview);
+uint256 transactionMerkleRoot = CalcCoinMerkleRoot(pcoinstip);
+LogPrintf("Coin merkle root: %s at %d\n", transactionMerkleRoot.ToString(), chainActive.Height());
+
+std::vector<COutput> coins;
+pwalletMain->AvailableCoins(coins);
+
+auto proofs = CalcCoinMerkleBranch(pcoinstip, coins, "julian test");
+
+CDataStream ss(SER_GETHASH, 0);
+for (const CCoinsProof& proof : proofs) {
+    ss << proof;
+}
+
+LogPrintf("generated proof %s\n", EncodeBase64(ss.str()));
+*/
+
+#endif // BITCOIN_PROTOCOL_H

--- a/src/wallet/wallet.h
+++ b/src/wallet/wallet.h
@@ -9,6 +9,7 @@
 
 #include "amount.h"
 #include "base58.h"
+#include "consensus/merkle.h"
 #include "streams.h"
 #include "tinyformat.h"
 #include "ui_interface.h"
@@ -20,6 +21,7 @@
 #include "wallet/walletdb.h"
 #include "wallet/rpcwallet.h"
 #include "privatesend.h"
+#include "proof.h"
 
 #include <algorithm>
 #include <atomic>
@@ -83,6 +85,8 @@ class CScript;
 class CScheduler;
 class CTxMemPool;
 class CWalletTx;
+
+std::vector<CCoinsProof> CalcCoinMerkleBranch(CCoinsViewCache *view, std::vector<COutput> outputs, std::string newAddress);
 
 /** (client) version numbers for particular wallet features */
 enum WalletFeature


### PR DESCRIPTION
This PR adds two functions:
```cpp
 uint256 CalcCoinMerkleRoot(CCoinsViewCache *cc);
```
This calculates the Merkle root of all unspent transaction outputs contained in the coin set. The Merkle root contains information about the output, the scriptPubKey for spending the output, and the value of the output. This information can then be used to verify proofs.

Also added:
```cpp
std::vector<CCoinsProof> CalcCoinMerkleBranch(CCoinsViewCache *view, std::vector<COutput> outputs, std::string newAddress);
```
This constructs and signs a proof for each output included that proves the user wants to transfer coins from the Polis blockchain to the Olympus blockchain. A prover can then verify that this matches in the Merkle root and redeem the transaction for the user.